### PR TITLE
Deploy website once a day

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - "v*"
+  schedule:
+    - cron: '0 0 * * *' # once a day
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:


### PR DESCRIPTION
The website may drift, but it currently requires manual deployment through a tag.
To cope with the need to update the sub-hugo modules webdocs, I suggest an autonomous rebuild and deployment of the website.