### PR TITLE
fix: upgrade hugo version to 0.148.1

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f # v3.0.0
         with:
-          hugo-version: '0.140.0'
+          hugo-version: '0.148.1'
           extended: true
 
       - name: Setup Node

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -121,7 +121,7 @@ module:
   replacements: github.com/ctfer-io/chall-manager -> ../modules/chall-manager # protips: relative from ./themes
   hugoVersion:
     extended: true
-    min: 0.140.0
+    min: 0.146.0 # docsy v0.12.0
   imports:
     - path: github.com/google/docsy
       disable: false


### PR DESCRIPTION
This PR change the Hugo version due to docsy 0.12.0 limitation. (need >= 0.146.0).

This fix the broken CI. 