### PR TITLE
Customize docs/blog into the home style for consistency

### DIFF
--- a/assets/css/docs.css
+++ b/assets/css/docs.css
@@ -1,0 +1,62 @@
+/*
+  Tailwind build for Docsy (docs/blog) pages: theme tokens + utilities only.
+  Preflight (the global reset) is intentionally NOT loaded so it cannot reset
+  Docsy's Bootstrap content. Instead we re-apply, scoped to the house chrome
+  only, the few Preflight rules the header/footer depend on. These live in the
+  `base` layer so utilities (text-primary, mb-2, ...) keep winning the cascade.
+*/
+@layer theme, base, components, utilities;
+@import 'tailwindcss/theme.css' layer(theme);
+@import 'tailwindcss/utilities.css' layer(utilities);
+
+/*
+  The split import above (used to drop Preflight) does NOT carry the automatic
+  source detection that the full `@import "tailwindcss"` in styles.css provides.
+  Without it Tailwind has nothing to scan, so the chrome's responsive utilities
+  that appear ONLY in the partials (xl:text-start, xl:items-start, xl:flex-row)
+  are never generated, and the footer falls back to its centred mobile layout.
+  Point Tailwind at the layouts so every header/footer class is emitted, exactly
+  like the homepage build. (Path is relative to this file.)
+*/
+@source '../../layouts';
+
+@theme {
+  --color-primary: {{ (default "#b43c2c" site.Params.colors.primary) }};
+  --color-secondary: {{ (default "#ebb850" site.Params.colors.secondary) }};
+  --color-tertiary: {{ (default "#dcf0ff" site.Params.colors.tertiary) }};
+}
+
+@layer base {
+  header nav,
+  footer {
+    font-family: 'Inter', system-ui, sans-serif;
+  }
+
+  /* No bullets/indent on the nav and footer menus. */
+  header nav ul,
+  footer ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  /* Links carry colour via utilities, not browser underlines. */
+  header nav a,
+  footer a {
+    text-decoration: none;
+  }
+
+  /* Drop UA margins; spacing comes from utilities (mb-2, ...). */
+  header nav :where(h1, h2, h3, h4, h5, h6, p),
+  footer :where(h1, h2, h3, h4, h5, h6, p) {
+    margin: 0;
+  }
+
+  /* Bare toggle button for the mobile menu. */
+  header nav button {
+    padding: 0;
+    border: 0;
+    background: none;
+    cursor: pointer;
+  }
+}

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -531,3 +531,38 @@ footer {
     }
   }
 }
+
+// Print.
+// On screen we centre the docs column (ctfer-container) and cap prose to a
+// readable measure. Ctrl+P on a normal page keeps the screen CSS, so those
+// constraints (plus Bootstrap's `col-md-9` grid track left behind by the hidden
+// `.d-print-none` sidebars) squeeze the content onto a narrow, off-centre strip
+// that wastes most of the sheet. Release all of it for print so the content
+// spans the full page width. (Docsy already hides the sidebars for us.)
+@media print {
+  // Drop the centred max-width envelope and side padding.
+  .td-main {
+    max-width: none !important;
+    padding-inline: 0 !important;
+  }
+
+  // Zero the row gutter so the hidden columns leave no track and `main` has no
+  // residual gutter padding to offset.
+  .td-main > .row {
+    --bs-gutter-x: 0 !important;
+  }
+
+  // Let `main` take the whole row regardless of col-md-9 / col-xl-8, and drop the
+  // ps-md-5 reading indent.
+  .td-main > .row > main {
+    flex: 0 0 100% !important;
+    max-width: 100% !important;
+    padding-inline: 0 !important;
+  }
+
+  // Release the readability measure: every block that caps at var(--ctfer-measure)
+  // (prose, code, tables, cards, tabs) becomes max-width:none and fills the page.
+  .td-content {
+    --ctfer-measure: none;
+  }
+}

--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -1,0 +1,533 @@
+// House layout & polish for Docsy (docs/blog).
+// Appended after all Docsy styles, so plain rules here win without !important.
+// Goal: a calm, content-forward docs surface in the brand palette, visually
+// consistent with the homepage.
+
+// Shared horizontal envelope. The homepage uses Tailwind's responsive
+// `.container`; on Docsy pages that same class resolves to Bootstrap's
+// (different) widths, so the header logo + menu land at a different x than on
+// the homepage. We re-declare the header container and the docs body envelope
+// with Tailwind's default container breakpoints, so the header lines up across
+// home and docs/blog and the docs content sits right under it.
+@mixin ctfer-container {
+  width: 100%;
+  max-width: none;
+  margin-inline: auto;
+  // The chrome containers carry `px-4`. On the homepage that's Tailwind's
+  // px-4 (1rem). On Docsy pages Tailwind's px-4 isn't generated, so the class
+  // resolves to Bootstrap's `.px-4` utility, which is 1.5rem AND !important.
+  // We must match the homepage's 1rem, so we need !important to win the cascade.
+  padding-inline: 1rem !important;
+
+  @media (min-width: 40rem) {
+    max-width: 40rem;
+  }
+  @media (min-width: 48rem) {
+    max-width: 48rem;
+  }
+  @media (min-width: 64rem) {
+    max-width: 64rem;
+  }
+  @media (min-width: 80rem) {
+    max-width: 80rem;
+  }
+  @media (min-width: 96rem) {
+    max-width: 96rem;
+  }
+}
+
+// Match the header nav's container without depending on a <header> ancestor:
+// the header nav is the only nav on the page with a `.container` as a *direct*
+// child (Docsy's breadcrumb/TOC navs are not), so this is unambiguous. Keeping
+// the `>` avoids the nested `.container` inside the mobile overlay (#navbarContent).
+nav > .container,
+footer > .container {
+  @include ctfer-container;
+}
+
+// Constrain the docs *body* to the shared envelope so it lines up with the
+// header. NOT .td-outer: the footer is a direct child of .td-outer, so leaving
+// .td-outer full-width lets the footer background span the viewport edge-to-edge
+// like it does on the homepage.
+.td-main {
+  @include ctfer-container;
+  padding-top: 1.5rem;
+}
+
+.td-outer {
+  max-width: none;
+  padding-inline: 0;
+}
+
+// Chrome (header/footer) normalization.
+// The header and footer are Tailwind components that rely on Tailwind's
+// preflight reset, which we do NOT load on Docsy pages (it would reset Docsy's
+// content). So Bootstrap's reboot leaks into the chrome: <h*> get Bootstrap's
+// large sizes (beating Tailwind's text-lg), links get Bootstrap's colour, lists
+// regain bullets. Re-assert the homepage's intended baseline here.
+// (Sizes/weights mirror the partials' utilities: text-lg / font-bold / mb-2.)
+header nav,
+footer {
+  ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  p {
+    margin: 0;
+  }
+
+  :is(h1, h2, h3, h4, h5, h6) {
+    margin: 0 0 0.5rem; // mb-2
+    font-size: 1.125rem; // text-lg
+    line-height: 1.75rem;
+    font-weight: 700; // font-bold
+  }
+
+  // Tailwind preflight (not loaded on Docsy pages) sets svg { display: block }.
+  // Bootstrap's reboot leaves svg inline (vertical-align: middle), which sits the
+  // footer's location pin on the text baseline and nudges it off its label's
+  // centre line. Match the homepage so the pin aligns.
+  svg {
+    display: block;
+  }
+}
+
+// Footer text + links: muted like the homepage, not Bootstrap's link colour.
+// (Headings keep the brand red via their `.text-primary` utility.)
+footer {
+  color: #0000009c; // mirrors the homepage's html { color }
+
+  // Bootstrap's .gap-3 (1rem) and .gap-4 (1.5rem) utilities are !important, so
+  // they override the footer's Tailwind gap-3 (0.75rem) / gap-4 (1rem) on Docsy
+  // pages (the same class of collision as .px-4).
+  // Re-assert the Tailwind values so the inter-element spacing matches the homepage.
+  .gap-3 {
+    gap: 0.75rem !important;
+  }
+  .gap-4 {
+    gap: 1rem !important;
+  }
+
+  a {
+    color: inherit;
+    text-decoration: none;
+
+    &:hover {
+      color: $primary;
+    }
+  }
+}
+
+// Footer desktop layout (Docsy / blog pages).
+// The shared footer is a Tailwind partial whose desktop layout comes from xl:
+// utilities (xl:text-start, xl:items-start, xl:flex-row). On Docsy pages the
+// chrome's Tailwind utilities are emitted as !important, so the base mobile
+// classes (text-center, items-center, flex-col) beat an ordinary override and
+// the footer stays in its centered mobile layout. Force the desktop layout with
+// !important so it wins, gated to xl (80rem = Tailwind's xl) so the narrow-screen
+// layout still matches the homepage's centred one. Scoped to .grid so the
+// copyright line below stays centred.
+@media (min-width: 80rem) {
+  footer .grid {
+    // Headings, description, list items + the location label: left-aligned.
+    :is(h2, p, li),
+    li > span {
+      text-align: left !important;
+    }
+
+    // Logo / description / social column: left-aligned (xl:items-start).
+    > div:first-child {
+      align-items: flex-start !important;
+    }
+
+    // Location row: pin beside its label (xl:flex-row). The gap comes from the
+    // .gap-4 rule above (1rem), matching the homepage no override needed here.
+    li.flex-col {
+      flex-direction: row !important;
+      align-items: center !important;
+    }
+  }
+}
+
+// Left sidebar.
+// Docsy offsets the sidebar by 4rem to clear its *fixed* navbar; ours is in
+// normal flow, so drop the offset and let it stick just below the header.
+.td-sidebar {
+  @include media-breakpoint-up(md) {
+    padding-top: 1.5rem;
+    border-right: 1px solid var(--bs-border-color);
+  }
+}
+
+.td-sidebar-nav {
+  @supports (position: sticky) {
+    position: sticky;
+    top: 1.5rem;
+    max-height: calc(100vh - 3rem);
+    overflow-y: auto;
+  }
+}
+
+// Custom docs navigation tree (markup: layouts/_partials/sidebar.html).
+// `tree`-style hierarchy with CSS-drawn connectors (continuous across wrapped
+// titles, no gaps), CSS-only collapsible folders (collapsed unless on the
+// active path), top-level sections bolder/bigger.
+.ctfer-docnav {
+  font-size: 0.9rem;
+  --cdn-guide: var(--bs-border-color);
+  --cdn-indent: 1.25em;
+  --cdn-tick: 0.85em; // vertical offset of the horizontal connector
+
+  &__root {
+    display: block;
+    margin-bottom: 0.5rem;
+    padding-bottom: 0.45rem;
+    border-bottom: 1px solid var(--bs-border-color);
+    color: var(--bs-emphasis-color);
+    font-weight: 700;
+    font-size: 1.05rem;
+    text-decoration: none;
+
+    &:hover,
+    &.is-active {
+      color: $primary;
+    }
+  }
+
+  &__list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  &__item {
+    position: relative;
+    margin: 0;
+    padding-left: var(--cdn-indent);
+
+    // Vertical guide: spans the item's full height (incl. its children), so the
+    // line stays continuous however many lines a title wraps to.
+    &::before {
+      content: "";
+      position: absolute;
+      left: 0;
+      top: 0;
+      bottom: 0;
+      border-left: 1px solid var(--cdn-guide);
+    }
+
+    // Horizontal connector at the first text line.
+    &::after {
+      content: "";
+      position: absolute;
+      left: 0;
+      top: var(--cdn-tick);
+      width: 0.8em;
+      border-top: 1px solid var(--cdn-guide);
+    }
+
+    // Last sibling: vertical stops at the elbow.
+    &:last-child::before {
+      bottom: auto;
+      height: var(--cdn-tick);
+    }
+  }
+
+  &__row {
+    display: flex;
+    align-items: flex-start;
+  }
+
+  &__link {
+    flex: 1 1 auto;
+    min-width: 0;
+    padding: 0.15rem 0;
+    line-height: 1.4;
+    color: var(--bs-body-color);
+    text-decoration: none;
+
+    &:hover {
+      color: $primary;
+    }
+
+    &.is-folder {
+      font-weight: 600;
+      color: var(--bs-emphasis-color);
+    }
+
+    &.is-active {
+      color: $primary;
+      font-weight: 600;
+    }
+  }
+
+  // Top-level sections: bolder and a touch larger.
+  &__item.is-top > .ctfer-docnav__row > .ctfer-docnav__link {
+    font-weight: 700;
+    font-size: 0.98rem;
+  }
+
+  // Collapse affordance.
+  &__caret {
+    flex: none;
+    width: 1.1em;
+    margin-left: 0.15rem;
+    padding: 0.15rem 0;
+    line-height: 1.4;
+    text-align: center;
+    color: var(--bs-secondary-color);
+    cursor: pointer;
+    user-select: none;
+    transition: transform 0.15s ease;
+
+    &::before {
+      content: "\25B8"; // right-pointing triangle
+      font-size: 0.7em;
+    }
+  }
+
+  // CSS-only collapse: hidden checkbox drives the child list + caret rotation.
+  &__toggle {
+    position: absolute;
+    width: 0;
+    height: 0;
+    opacity: 0;
+  }
+
+  &__toggle:not(:checked) ~ &__list {
+    display: none;
+  }
+
+  &__toggle:checked ~ &__row .ctfer-docnav__caret {
+    transform: rotate(90deg);
+  }
+}
+
+// Right table of contents
+.td-sidebar-toc {
+  @supports (position: sticky) {
+    top: 1.5rem;
+    height: calc(100vh - 3rem);
+  }
+}
+
+#TableOfContents a.active,
+.td-toc a.active {
+  color: $primary;
+  font-weight: 600;
+}
+
+// Content column, constrain measure for readability.
+.td-content {
+  // The column is wide so figures/diagrams can use the space, but running prose
+  // shouldn't be that long to read. Cap text-level blocks to a readable measure
+  // (they sit left in the column); figures, diagrams, tables, code, and media are
+  // left uncapped so they fill the full width. Tune the measure here.
+  --ctfer-measure: 54rem;
+
+  > p:not(:has(img, svg, picture, video, iframe, .mermaid)),
+  > ul,
+  > ol,
+  > dl,
+  > blockquote,
+  > .alert,
+  > .lead,
+  > .highlight, // code blocks: share the text measure so they don't drift
+  > pre,        // (Docsy otherwise caps these at max-width:80%, ~off by a hair)
+  > h1,
+  > h2,
+  > h3,
+  > h4,
+  > h5,
+  > h6 {
+    max-width: var(--ctfer-measure);
+  }
+
+  // Docsy caps its card panes and tabbed panes at max-width:80% too, so they
+  // drift off the shared measure. Pull them onto --ctfer-measure as well.
+  // (0,3,0) beats Docsy's (0,2,0) and loads later, so it wins.
+  .td-card-group.card-group,
+  .td-card.card,
+  > .tab-content .tab-pane {
+    max-width: var(--ctfer-measure);
+  }
+
+  > h1 {
+    font-weight: 700;
+    margin-bottom: 0.75rem;
+  }
+
+  > h2 {
+    margin-top: 2.5rem;
+    padding-top: 0.5rem;
+  }
+
+  .lead {
+    color: var(--bs-secondary-color);
+    font-size: 1.15rem;
+  }
+}
+
+// Tables.
+// Docsy @extends every markdown table into .table.table-striped.table-responsive
+// (+ display:block for horizontal scroll). Restyle into a cleaner, branded
+// table: top-aligned cells, a rust header band with light text, rust-tinted
+// zebra rows, and a slightly denser font so wide multi-column tables wrap less.
+//
+// IMPORTANT: Docsy @extends every table, so its rules compile to
+// `.td-content table:not(.td-initial) > ... > *` — the `:not(.td-initial)` is a
+// class, so Docsy's cell-background rule is (0,2,2) and beats a plain
+// `.td-content table ...`. We mirror that base selector (and add element depth)
+// so our header/zebra actually win.
+.td-content table:not(.td-initial) {
+  // Shrink-wrap to the actual columns so the card/border hugs small tables
+  // (Docsy forces display:block + width:100%), but cap at the shared text
+  // measure so wide tables stop at the same right edge as the prose instead of
+  // running past it. Below that, cells wrap / the block scrolls.
+  width: fit-content;
+  max-width: var(--ctfer-measure);
+  margin-block: 1.5rem;
+  font-size: 0.9rem;
+  line-height: 1.45;
+
+  // Rounded card. The table is display:block + overflow-x:auto (Docsy's
+  // wrapper-less responsive), so border-radius clips the corners while
+  // horizontal scroll still works on small screens; a light outer border makes
+  // all four rounded corners read.
+  border: 1px solid var(--bs-border-color);
+  border-radius: 0.5rem;
+
+  // (0,2,3) beats Docsy's cell background (0,2,2).
+  thead th {
+    vertical-align: middle;
+    text-align: center;
+    background-color: #b43c2c; // brand rust (literal, like the alert colors)
+    color: #fff;
+    font-weight: 700;
+  }
+
+  th,
+  td {
+    vertical-align: top;
+    padding: 0.55rem 0.8rem;
+  }
+
+  // Drop the last row's cell border so it doesn't double the rounded outer edge.
+  tbody tr:last-child > * {
+    border-bottom: 0;
+  }
+
+  // Keep scheme strings like `s3://` from breaking mid-token.
+  th code,
+  td code {
+    white-space: nowrap;
+  }
+
+  // Rust zebra. Docsy's striped rule feeds --bs-table-bg-type from
+  // --bs-table-striped-bg at a specificity we can't undercut, so we set
+  // --bs-table-bg-type directly on the same odd-row cells (identical selector →
+  // source order decides, and _styles_project loads last, so we win).
+  > tbody > tr:nth-of-type(odd) > * {
+    --bs-table-bg-type: #f3ddd9; // brand rust tint
+  }
+}
+
+// Use the horizontal space: the TOC column only needs room for short links, so
+// trim it and let the content column grow into the slack (the old 54rem cap and
+// the full col-xl-2 TOC left a wide gap on the right). xl only; smaller screens
+// keep Docsy's stacked/responsive layout.
+@include media-breakpoint-up(xl) {
+  .td-main > .row > .td-sidebar-toc {
+    flex: 0 0 auto;
+    width: 14rem;
+    max-width: 14rem;
+  }
+
+  .td-main > .row > main {
+    flex: 1 1 0%;
+    width: auto;
+    max-width: none;
+  }
+}
+
+// Section landing.
+// Turn the bare list into a responsive card grid so landing
+// pages (e.g. /docs) feel intentional rather than empty.
+.section-index {
+  hr.panel-line {
+    display: none;
+  }
+
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
+  gap: 1.25rem;
+  margin-top: 1.75rem;
+
+  .entry {
+    // Anchor for the stretched link below: the whole card becomes clickable.
+    position: relative;
+    margin: 0;
+    padding: 1.25rem 1.4rem;
+    background: #fff;
+    border: 1px solid var(--bs-border-color);
+    border-radius: 0.6rem;
+    transition:
+      transform 0.18s ease,
+      box-shadow 0.18s ease,
+      border-color 0.18s ease;
+
+    &:hover {
+      transform: translateY(-2px);
+      border-color: $primary;
+      box-shadow: 0 8px 22px rgba(0, 0, 0, 0.07);
+    }
+
+    h5 {
+      margin-bottom: 0.4rem;
+
+      a {
+        color: $primary;
+        font-weight: 700;
+        text-decoration: none;
+
+        // Stretch the title link to cover the entire card (no markup change).
+        &::after {
+          content: '';
+          position: absolute;
+          inset: 0;
+        }
+      }
+    }
+
+    p {
+      margin: 0;
+      color: var(--bs-secondary-color);
+      font-size: 0.95rem;
+      line-height: 1.5;
+    }
+  }
+}
+
+// Keep the box style (rounded, thick left rule), but restore Docsy's original
+// alert palette. The brand red/gold/blue is for the chrome only; our
+// $primary/$secondary/$info overrides had bled into .alert-primary (e.g. "Tips
+// & Tricks") etc. These are Docsy's defaults.
+.td-content .alert {
+  border-left-width: 4px;
+  border-radius: 0.4rem;
+}
+
+// `info` uses a darker teal than Docsy's #c0e0de (whose title was illegible on
+// its own tint); same family, just readable. primary/secondary keep Docsy's.
+@each $name, $c in ("primary": #30638e, "secondary": #ffa630, "info": #357a72) {
+  .td-content .alert-#{$name} {
+    background-color: tint-color($c, 80%);
+    border-color: $c;
+
+    .alert-heading {
+      color: $c;
+    }
+  }
+}

--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -1,0 +1,24 @@
+// House theme for Docsy (docs/blog).
+// Imported before Bootstrap & Docsy defaults, so these win over their
+// `!default` values. Mirrors the Tailwind tokens in assets/css/styles.css
+// (single source of truth is a later cleanup).
+
+// --- Brand palette (the three core aspects) ---------------------------------
+$primary: #b43c2c;   // Research & Development
+$secondary: #ebb850; // Infra as Code
+$info: #479abf;      // Software Development
+
+// --- Typography -------------------------------------------------------------
+// Inter is injected on Docsy pages via layouts/_partials/hooks/head-end.html,
+// so we disable Docsy's Google Fonts fetch and point the stack at Inter.
+$td-enable-google-fonts: false;
+$font-family-sans-serif: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+$font-family-base: $font-family-sans-serif;
+$headings-font-weight: 700;
+
+// --- Links: coloured, underline only on hover (matches the homepage) --------
+$link-color: $primary;
+$link-decoration: none;
+$link-hover-color: shade-color($primary, 15%);
+$link-hover-decoration: underline;
+ 

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -2,6 +2,6 @@
 title: Docs
 ---
 
-{{% alert title="Warning" color="warning" %}}
+{{< alert title="Warning" color="warning" >}}
 Currently entering public beta phase, for any issue: ctfer-io@protonmail.com 
-{{% /alert %}}
+{{< /alert >}}

--- a/layouts/_partials/footer.html
+++ b/layouts/_partials/footer.html
@@ -1,0 +1,2 @@
+{{/* Project override: use the house footer on Docsy (docs/blog) pages. */}}
+{{ partial "shared/footer.html" . }}

--- a/layouts/_partials/hooks/head-end.html
+++ b/layouts/_partials/hooks/head-end.html
@@ -1,0 +1,32 @@
+{{/*
+  Project override of Docsy's head-end hook.
+  Docsy pages ship Bootstrap, not our Tailwind utilities, so the house
+  header/footer would be unstyled. Load a preflight-free Tailwind build
+  (utilities + theme only) plus fonts and the nav toggler.
+  No preflight = no global reset, so Docsy's own content styling is left
+  untouched.
+*/}}
+{{ with (templates.Defer (dict "key" "global-docs")) }}
+  {{ with resources.Get "css/docs.css" }}
+    {{ with resources.ExecuteAsTemplate "css/docs.css" $ . }}
+      {{ $opts := dict "inlineImports" true "optimize" true "minify" true }}
+      {{ with . | css.TailwindCSS $opts | fingerprint }}
+        <link rel="stylesheet" href="{{ .RelPermalink }}" integrity="{{ .Data.Integrity }}" crossorigin="anonymous" />
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ with resources.Get "css/fonts.css" }}
+  {{ with resources.ExecuteAsTemplate "css/fonts.css" $ . }}
+    {{ $opts := dict "inlineImports" true "optimize" true "minify" true }}
+    {{ with . | css.TailwindCSS $opts | fingerprint }}
+      <link rel="stylesheet" href="{{ .RelPermalink }}" integrity="{{ .Data.Integrity }}" crossorigin="anonymous" />
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ with resources.Get "js/main.js" }}
+  {{ $main := . | js.Build (dict "minify" "true") | fingerprint }}
+  <script src="{{ $main.RelPermalink }}" defer></script>
+{{ end }}

--- a/layouts/_partials/navbar.html
+++ b/layouts/_partials/navbar.html
@@ -1,0 +1,2 @@
+{{/* Project override: use the house header on Docsy (docs/blog) pages. */}}
+{{ partial "shared/header.html" . }}

--- a/layouts/_partials/shared/header.html
+++ b/layouts/_partials/shared/header.html
@@ -1,50 +1,55 @@
-<nav class="">
-  <div class="container mx-auto flex items-center justify-between px-4 py-6 h-auto">
-    <a class="flex items-center" href="{{ .Site.BaseURL }}">
-      {{ partial "utilities/image.html" (dict "src" "images/logo.png" "class" "h-12 w-auto") }}
-    </a>
-    <button
-      class="cursor-pointer xl:hidden"
-      type="button"
-      data-toggle-target="#navbarContent"
-      data-toggle-class="-translate-y-full"
-      aria-label="Toggle Navigation"
-    >
-      {{ partial "heroicons/bars-4" }}
+{{/* Owns its own <header> landmark so the homepage and the Docsy docs layout
+     render the chrome from an identical structure (header > nav > .container).
+     The docs baseof override calls this directly, with no extra <header>. */}}
+<header>
+  <nav class="">
+    <div class="container mx-auto flex items-center justify-between px-4 py-6 h-auto">
+      <a class="flex items-center" href="{{ .Site.BaseURL }}">
+        {{ partial "utilities/image.html" (dict "src" "images/logo.png" "class" "h-12 w-auto") }}
+      </a>
+      <button
+        class="cursor-pointer xl:hidden"
+        type="button"
+        data-toggle-target="#navbarContent"
+        data-toggle-class="-translate-y-full"
+        aria-label="Toggle Navigation"
+      >
+        {{ partial "heroicons/bars-4" }}
 
-    </button>
-    <div
-      class="fixed inset-0 flex -translate-y-full flex-col items-center justify-center gap-8 bg-white duration-500 xl:relative xl:translate-y-0 xl:flex-row"
-      id="navbarContent"
-    >
-      <div class="container absolute top-0 mx-auto flex items-center justify-between px-4 py-6 xl:hidden">
-        <a class="flex items-center xl:hidden" href="{{ .Site.BaseURL }}">
-          {{ partial "utilities/image.html" (dict "src" "images/logo.png" "class" "h-12 w-auto") }}
-        </a>
-        <button
-          class="cursor-pointer xl:hidden"
-          type="button"
-          data-toggle-target="#navbarContent"
-          data-toggle-class="-translate-y-full"
-          aria-label="Toggle Navigation"
-        >
-          {{ partial "heroicons/x-mark" }}
-        </button>
+      </button>
+      <div
+        class="fixed inset-0 flex -translate-y-full flex-col items-center justify-center gap-8 bg-white duration-500 xl:relative xl:translate-y-0 xl:flex-row"
+        id="navbarContent"
+      >
+        <div class="container absolute top-0 mx-auto flex items-center justify-between px-4 py-6 xl:hidden">
+          <a class="flex items-center xl:hidden" href="{{ .Site.BaseURL }}">
+            {{ partial "utilities/image.html" (dict "src" "images/logo.png" "class" "h-12 w-auto") }}
+          </a>
+          <button
+            class="cursor-pointer xl:hidden"
+            type="button"
+            data-toggle-target="#navbarContent"
+            data-toggle-class="-translate-y-full"
+            aria-label="Toggle Navigation"
+          >
+            {{ partial "heroicons/x-mark" }}
+          </button>
+        </div>
+        <ul class="flex flex-col gap-8 xl:flex-row">
+          {{ range site.Menus.main }}
+            <li class="text-center">
+              <a class="text-primary" href="{{ .URL }}">{{ .Name }}</a>
+            </li>
+          {{ end }}
+        </ul>
+        <ul class="flex flex-col gap-8 xl:flex-row">
+          {{ range .Site.Menus.buttons }}
+            <li class="text-center">
+              {{ partial "components/button/primary" (dict "label" .Name "href" .URL ) }}
+            </li>
+          {{ end }}
+        </ul>
       </div>
-      <ul class="flex flex-col gap-8 xl:flex-row">
-        {{ range site.Menus.main }}
-          <li class="text-center">
-            <a class="text-primary" href="{{ .URL }}">{{ .Name }}</a>
-          </li>
-        {{ end }}
-      </ul>
-      <ul class="flex flex-col gap-8 xl:flex-row">
-        {{ range .Site.Menus.buttons }}
-          <li class="text-center">
-            {{ partial "components/button/primary" (dict "label" .Name "href" .URL ) }}
-          </li>
-        {{ end }}
-      </ul>
     </div>
-  </div>
-</nav>
+  </nav>
+</header>

--- a/layouts/_partials/sidebar.html
+++ b/layouts/_partials/sidebar.html
@@ -1,10 +1,10 @@
 {{/*
   Project override of Docsy's left navigation sidebar.
 
-  Rooted at the page's top-level section (.Section) — reliable for our
-  module-mounted docs, unlike Docsy's .FirstSection.
+  Rooted at the page's top-level section (.Section), reliable for our
+  module-mounted docs unlike Docsy's .FirstSection.
 
-  Renders a `tree`-style hierarchy. The connectors are drawn entirely in CSS
+  Renders a tree-style hierarchy. The connectors are drawn entirely in CSS
   (see _styles_project.scss): each item carries a vertical + horizontal border
   guide, so the lines stay continuous across wrapped titles and have no gaps.
   Folders (entries with children) are collapsible via a CSS-only checkbox and

--- a/layouts/_partials/sidebar.html
+++ b/layouts/_partials/sidebar.html
@@ -1,0 +1,50 @@
+{{/*
+  Project override of Docsy's left navigation sidebar.
+
+  Rooted at the page's top-level section (.Section) — reliable for our
+  module-mounted docs, unlike Docsy's .FirstSection.
+
+  Renders a `tree`-style hierarchy. The connectors are drawn entirely in CSS
+  (see _styles_project.scss): each item carries a vertical + horizontal border
+  guide, so the lines stay continuous across wrapped titles and have no gaps.
+  Folders (entries with children) are collapsible via a CSS-only checkbox and
+  start collapsed, except along the active path.
+*/ -}}
+{{ $root := site.GetPage .Section -}}
+{{ with $root -}}
+<nav class="td-sidebar-nav ctfer-docnav" id="td-section-nav" aria-label="Documentation navigation">
+  <a class="ctfer-docnav__root{{ if eq . $ }} is-active{{ end }}" href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
+  {{ template "ctfer-docnav-tree" (dict "section" . "page" $ "depth" 0) -}}
+</nav>
+{{ end -}}
+
+{{ define "ctfer-docnav-tree" -}}
+  {{ $p := .page -}}
+  {{ $depth := .depth -}}
+  {{ $children := (where (union .section.Sections .section.Pages) ".Params.toc_hide" "!=" true).ByWeight -}}
+  {{ with $children -}}
+  <ul class="ctfer-docnav__list">
+    {{ range . -}}
+      {{ $isCurrent := eq . $p -}}
+      {{ $onPath := or $isCurrent ($p.IsDescendant .) -}}
+      {{ $hasKids := gt (len (where (union .Sections .Pages) ".Params.toc_hide" "!=" true)) 0 -}}
+      {{ $linkClass := printf "ctfer-docnav__link%s%s" (cond $hasKids " is-folder" "") (cond $isCurrent " is-active" "") -}}
+      <li class="ctfer-docnav__item{{ if eq $depth 0 }} is-top{{ end }}">
+        {{ if $hasKids -}}
+          {{ $id := printf "cdn-%d-%s" $depth (anchorize .RelPermalink) -}}
+          <input class="ctfer-docnav__toggle" type="checkbox" id="{{ $id }}"{{ if $onPath }} checked{{ end }} />
+          <span class="ctfer-docnav__row">
+            <a class="{{ $linkClass }}" href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
+            <label class="ctfer-docnav__caret" for="{{ $id }}" aria-hidden="true"></label>
+          </span>
+          {{ template "ctfer-docnav-tree" (dict "section" . "page" $p "depth" (add $depth 1)) -}}
+        {{ else -}}
+          <span class="ctfer-docnav__row">
+            <a class="{{ $linkClass }}" href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
+          </span>
+        {{ end -}}
+      </li>
+    {{ end -}}
+  </ul>
+  {{ end -}}
+{{ end -}}

--- a/layouts/docs/baseof.html
+++ b/layouts/docs/baseof.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html itemscope itemtype="http://schema.org/WebPage"
+    {{- with .Site.Language.LanguageDirection }} dir="{{ . }}" {{- end -}}
+    {{ with .Site.Language.Lang }} lang="{{ . }}" {{- end }} {{/**/ -}}
+    class="no-js">
+  <head>
+    {{ partial "head.html" . }}
+  </head>
+  <body class="td-{{ .Kind }}{{ with .Page.Params.body_class }} {{ . }}{{ end }}">
+    {{/* The header partial (shared/header.html) now owns its own <header>, so we
+         call it directly with no extra wrapper, exactly like the homepage
+         baseof. This keeps the chrome's container context identical across both
+         layouts. (Docsy's stock baseof wraps this in its own <header>.) */}}
+    {{ partial "navbar.html" . }}
+
+    <div class="container-fluid td-outer">
+      <div class="td-main">
+        <div class="row flex-xl-nowrap">
+          <aside class="col-12 col-md-3 col-xl-2 td-sidebar d-print-none">
+            {{ partial "sidebar.html" . }}
+          </aside>
+          <aside class="d-none d-xl-block col-xl-2 td-sidebar-toc d-print-none">
+            {{ partial "page-meta-links.html" . }}
+            {{ partial "toc.html" . }}
+            {{ partial "taxonomy_terms_clouds.html" . }}
+          </aside>
+          <main class="col-12 col-md-9 col-xl-8 ps-md-5" role="main">
+            {{ partial "version-banner.html" . }}
+            {{ if not (.Param "ui.breadcrumb_disable") -}}
+              {{ partial "breadcrumb.html" . -}}
+            {{ end -}}
+            {{ block "main" . }}{{ end }}
+          </main>
+        </div>
+      </div>
+    </div>
+
+    {{/* Footer outside .td-outer (a sibling of the content envelope, like the
+         homepage) so it spans full width and its .container centres identically
+         on both layouts. (Docsy's stock baseof nests it inside .td-outer.) */}}
+    {{ partial "footer.html" . }}
+
+    {{ partial "scripts.html" . }}
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
         "package.json": "^2.0.1"
       },
       "devDependencies": {
-        "@tailwindcss/cli": "^4.0.0",
+        "@tailwindcss/cli": "^4.1.16",
         "@tailwindcss/typography": "^0.5.9",
         "autoprefixer": "^10.4.16",
         "postcss": "^8.4.31",
@@ -16,41 +16,28 @@
         "prettier": "^3.0.3",
         "prettier-plugin-go-template": "^0.0.15",
         "prettier-plugin-tailwindcss": "^0.5.6",
-        "tailwindcss": "^4.0.0"
-      }
-    },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@isaacs/fs-minipass": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "dev": true,
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "tailwindcss": "^4.1.16"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
-      "integrity": "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
@@ -59,21 +46,24 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
-      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
-      "dev": true
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.29",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
-      "integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -410,74 +400,73 @@
       }
     },
     "node_modules/@tailwindcss/cli": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/cli/-/cli-4.1.11.tgz",
-      "integrity": "sha512-7RAFOrVaXCFz5ooEG36Kbh+sMJiI2j4+Ozp71smgjnLfBRu7DTfoq8DsTvzse2/6nDeo2M3vS/FGaxfDgr3rtQ==",
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/cli/-/cli-4.1.16.tgz",
+      "integrity": "sha512-dsnANPrh2ZooHyZ/8uJhc9ecpcYtufToc21NY09NS9vF16rxPCjJ8dP7TUAtPqlUJTHSmRkN2hCdoYQIlgh4fw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/watcher": "^2.5.1",
-        "@tailwindcss/node": "4.1.11",
-        "@tailwindcss/oxide": "4.1.11",
-        "enhanced-resolve": "^5.18.1",
+        "@tailwindcss/node": "4.1.16",
+        "@tailwindcss/oxide": "4.1.16",
+        "enhanced-resolve": "^5.18.3",
         "mri": "^1.2.0",
         "picocolors": "^1.1.1",
-        "tailwindcss": "4.1.11"
+        "tailwindcss": "4.1.16"
       },
       "bin": {
         "tailwindcss": "dist/index.mjs"
       }
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.11.tgz",
-      "integrity": "sha512-yzhzuGRmv5QyU9qLNg4GTlYI6STedBWRE7NjxP45CsFYYq9taI0zJXZBMqIC/c8fViNLhmrbpSFS57EoxUmD6Q==",
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.16.tgz",
+      "integrity": "sha512-BX5iaSsloNuvKNHRN3k2RcCuTEgASTo77mofW0vmeHkfrDWaoFAFvNHpEgtu0eqyypcyiBkDWzSMxJhp3AUVcw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@ampproject/remapping": "^2.3.0",
-        "enhanced-resolve": "^5.18.1",
-        "jiti": "^2.4.2",
-        "lightningcss": "1.30.1",
-        "magic-string": "^0.30.17",
+        "@jridgewell/remapping": "^2.3.4",
+        "enhanced-resolve": "^5.18.3",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.30.2",
+        "magic-string": "^0.30.19",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.1.11"
+        "tailwindcss": "4.1.16"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.11.tgz",
-      "integrity": "sha512-Q69XzrtAhuyfHo+5/HMgr1lAiPP/G40OMFAnws7xcFEYqcypZmdW8eGXaOUIeOl1dzPJBPENXgbjsOyhg2nkrg==",
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.16.tgz",
+      "integrity": "sha512-2OSv52FRuhdlgyOQqgtQHuCgXnS8nFSYRp2tJ+4WZXKgTxqPy7SMSls8c3mPT5pkZ17SBToGM5LHEJBO7miEdg==",
       "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "detect-libc": "^2.0.4",
-        "tar": "^7.4.3"
-      },
+      "license": "MIT",
       "engines": {
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.1.11",
-        "@tailwindcss/oxide-darwin-arm64": "4.1.11",
-        "@tailwindcss/oxide-darwin-x64": "4.1.11",
-        "@tailwindcss/oxide-freebsd-x64": "4.1.11",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.11",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.1.11",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.1.11",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.1.11",
-        "@tailwindcss/oxide-linux-x64-musl": "4.1.11",
-        "@tailwindcss/oxide-wasm32-wasi": "4.1.11",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.1.11",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.1.11"
+        "@tailwindcss/oxide-android-arm64": "4.1.16",
+        "@tailwindcss/oxide-darwin-arm64": "4.1.16",
+        "@tailwindcss/oxide-darwin-x64": "4.1.16",
+        "@tailwindcss/oxide-freebsd-x64": "4.1.16",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.16",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.1.16",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.1.16",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.1.16",
+        "@tailwindcss/oxide-linux-x64-musl": "4.1.16",
+        "@tailwindcss/oxide-wasm32-wasi": "4.1.16",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.1.16",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.1.16"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.11.tgz",
-      "integrity": "sha512-3IfFuATVRUMZZprEIx9OGDjG3Ou3jG4xQzNTvjDoKmU9JdmoCohQJ83MYd0GPnQIu89YoJqvMM0G3uqLRFtetg==",
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.16.tgz",
+      "integrity": "sha512-8+ctzkjHgwDJ5caq9IqRSgsP70xhdhJvm+oueS/yhD5ixLhqTw9fSL1OurzMUhBwE5zK26FXLCz2f/RtkISqHA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -487,13 +476,14 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.11.tgz",
-      "integrity": "sha512-ESgStEOEsyg8J5YcMb1xl8WFOXfeBmrhAwGsFxxB2CxY9evy63+AtpbDLAyRkJnxLy2WsD1qF13E97uQyP1lfQ==",
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.16.tgz",
+      "integrity": "sha512-C3oZy5042v2FOALBZtY0JTDnGNdS6w7DxL/odvSny17ORUnaRKhyTse8xYi3yKGyfnTUOdavRCdmc8QqJYwFKA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -503,13 +493,14 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.11.tgz",
-      "integrity": "sha512-EgnK8kRchgmgzG6jE10UQNaH9Mwi2n+yw1jWmof9Vyg2lpKNX2ioe7CJdf9M5f8V9uaQxInenZkOxnTVL3fhAw==",
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.16.tgz",
+      "integrity": "sha512-vjrl/1Ub9+JwU6BP0emgipGjowzYZMjbWCDqwA2Z4vCa+HBSpP4v6U2ddejcHsolsYxwL5r4bPNoamlV0xDdLg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -519,13 +510,14 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.11.tgz",
-      "integrity": "sha512-xdqKtbpHs7pQhIKmqVpxStnY1skuNh4CtbcyOHeX1YBE0hArj2romsFGb6yUmzkq/6M24nkxDqU8GYrKrz+UcA==",
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.16.tgz",
+      "integrity": "sha512-TSMpPYpQLm+aR1wW5rKuUuEruc/oOX3C7H0BTnPDn7W/eMw8W+MRMpiypKMkXZfwH8wqPIRKppuZoedTtNj2tg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -535,13 +527,14 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.11.tgz",
-      "integrity": "sha512-ryHQK2eyDYYMwB5wZL46uoxz2zzDZsFBwfjssgB7pzytAeCCa6glsiJGjhTEddq/4OsIjsLNMAiMlHNYnkEEeg==",
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.16.tgz",
+      "integrity": "sha512-p0GGfRg/w0sdsFKBjMYvvKIiKy/LNWLWgV/plR4lUgrsxFAoQBFrXkZ4C0w8IOXfslB9vHK/JGASWD2IefIpvw==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -551,13 +544,14 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.11.tgz",
-      "integrity": "sha512-mYwqheq4BXF83j/w75ewkPJmPZIqqP1nhoghS9D57CLjsh3Nfq0m4ftTotRYtGnZd3eCztgbSPJ9QhfC91gDZQ==",
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.16.tgz",
+      "integrity": "sha512-DoixyMmTNO19rwRPdqviTrG1rYzpxgyYJl8RgQvdAQUzxC1ToLRqtNJpU/ATURSKgIg6uerPw2feW0aS8SNr/w==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -567,13 +561,14 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.11.tgz",
-      "integrity": "sha512-m/NVRFNGlEHJrNVk3O6I9ggVuNjXHIPoD6bqay/pubtYC9QIdAMpS+cswZQPBLvVvEF6GtSNONbDkZrjWZXYNQ==",
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.16.tgz",
+      "integrity": "sha512-H81UXMa9hJhWhaAUca6bU2wm5RRFpuHImrwXBUvPbYb+3jo32I9VIwpOX6hms0fPmA6f2pGVlybO6qU8pF4fzQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -583,13 +578,14 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.11.tgz",
-      "integrity": "sha512-YW6sblI7xukSD2TdbbaeQVDysIm/UPJtObHJHKxDEcW2exAtY47j52f8jZXkqE1krdnkhCMGqP3dbniu1Te2Fg==",
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.16.tgz",
+      "integrity": "sha512-ZGHQxDtFC2/ruo7t99Qo2TTIvOERULPl5l0K1g0oK6b5PGqjYMga+FcY1wIUnrUxY56h28FxybtDEla+ICOyew==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -599,13 +595,14 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.11.tgz",
-      "integrity": "sha512-e3C/RRhGunWYNC3aSF7exsQkdXzQ/M+aYuZHKnw4U7KQwTJotnWsGOIVih0s2qQzmEzOFIJ3+xt7iq67K/p56Q==",
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.16.tgz",
+      "integrity": "sha512-Oi1tAaa0rcKf1Og9MzKeINZzMLPbhxvm7rno5/zuP1WYmpiG0bEHq4AcRUiG2165/WUzvxkW4XDYCscZWbTLZw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -615,9 +612,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.11.tgz",
-      "integrity": "sha512-Xo1+/GU0JEN/C/dvcammKHzeM6NqKovG+6921MR6oadee5XPBaKOumrJCXvopJ/Qb5TH7LX/UAywbqrP4lax0g==",
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.16.tgz",
+      "integrity": "sha512-B01u/b8LteGRwucIBmCQ07FVXLzImWESAIMcUU6nvFt/tYsQ6IHz8DmZ5KtvmwxD+iTYBtM1xwoGXswnlu9v0Q==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -630,27 +627,29 @@
         "wasm32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.4.3",
-        "@emnapi/runtime": "^1.4.3",
-        "@emnapi/wasi-threads": "^1.0.2",
-        "@napi-rs/wasm-runtime": "^0.2.11",
-        "@tybys/wasm-util": "^0.9.0",
-        "tslib": "^2.8.0"
+        "@emnapi/core": "^1.5.0",
+        "@emnapi/runtime": "^1.5.0",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.0.7",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.4.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.11.tgz",
-      "integrity": "sha512-UgKYx5PwEKrac3GPNPf6HVMNhUIGuUh4wlDFR2jYYdkX6pL/rn73zTq/4pzUm8fOjAn5L8zDeHp9iXmUGOXZ+w==",
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.16.tgz",
+      "integrity": "sha512-zX+Q8sSkGj6HKRTMJXuPvOcP8XfYON24zJBRPlszcH1Np7xuHXhWn8qfFjIujVzvH3BHU+16jBXwgpl20i+v9A==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -660,28 +659,20 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.11.tgz",
-      "integrity": "sha512-YfHoggn1j0LK7wR82TOucWc5LDCguHnoS879idHekmmiR7g9HUtMw9MI0NHatS28u/Xlkfi9w5RJWgz2Dl+5Qg==",
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.16.tgz",
+      "integrity": "sha512-m5dDFJUEejbFqP+UXVstd4W/wnxA4F61q8SoL+mqTypId2T2ZpuxosNSgowiCnLp2+Z+rivdU0AqpfgiD7yCBg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/@tailwindcss/oxide/node_modules/detect-libc": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
-      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@tailwindcss/typography": {
@@ -892,15 +883,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/chownr": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "dev": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -1031,10 +1013,11 @@
       "dev": true
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.18.2",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.2.tgz",
-      "integrity": "sha512-6Jw4sE1maoRJo3q8MsSIn2onJFbLTOjY9hlx4DZXmOKvLRd1Ok2kXmAGXaafL2+ijsJZ1ClYbl/pmqr9+k4iUQ==",
+      "version": "5.18.3",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
+      "integrity": "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -1475,10 +1458,11 @@
       "integrity": "sha512-eL23u8oFooYTq6TtJKjp2RYjZnCkUYQvC0T/6fJfWykXJ3quvdDdzKZ3CEjy8b3JGOvLTjDYMEMIp5243R906A=="
     },
     "node_modules/jiti": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
-      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -1496,10 +1480,11 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.1.tgz",
-      "integrity": "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.2.tgz",
+      "integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -1511,26 +1496,49 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-darwin-arm64": "1.30.1",
-        "lightningcss-darwin-x64": "1.30.1",
-        "lightningcss-freebsd-x64": "1.30.1",
-        "lightningcss-linux-arm-gnueabihf": "1.30.1",
-        "lightningcss-linux-arm64-gnu": "1.30.1",
-        "lightningcss-linux-arm64-musl": "1.30.1",
-        "lightningcss-linux-x64-gnu": "1.30.1",
-        "lightningcss-linux-x64-musl": "1.30.1",
-        "lightningcss-win32-arm64-msvc": "1.30.1",
-        "lightningcss-win32-x64-msvc": "1.30.1"
+        "lightningcss-android-arm64": "1.30.2",
+        "lightningcss-darwin-arm64": "1.30.2",
+        "lightningcss-darwin-x64": "1.30.2",
+        "lightningcss-freebsd-x64": "1.30.2",
+        "lightningcss-linux-arm-gnueabihf": "1.30.2",
+        "lightningcss-linux-arm64-gnu": "1.30.2",
+        "lightningcss-linux-arm64-musl": "1.30.2",
+        "lightningcss-linux-x64-gnu": "1.30.2",
+        "lightningcss-linux-x64-musl": "1.30.2",
+        "lightningcss-win32-arm64-msvc": "1.30.2",
+        "lightningcss-win32-x64-msvc": "1.30.2"
       }
     },
-    "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.1.tgz",
-      "integrity": "sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==",
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.30.2.tgz",
+      "integrity": "sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.2.tgz",
+      "integrity": "sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -1544,13 +1552,14 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.1.tgz",
-      "integrity": "sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.2.tgz",
+      "integrity": "sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -1564,13 +1573,14 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.1.tgz",
-      "integrity": "sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.2.tgz",
+      "integrity": "sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "freebsd"
@@ -1584,13 +1594,14 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.1.tgz",
-      "integrity": "sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.2.tgz",
+      "integrity": "sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -1604,13 +1615,14 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.1.tgz",
-      "integrity": "sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.2.tgz",
+      "integrity": "sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -1624,13 +1636,14 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.1.tgz",
-      "integrity": "sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.2.tgz",
+      "integrity": "sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -1644,13 +1657,14 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.1.tgz",
-      "integrity": "sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.2.tgz",
+      "integrity": "sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -1664,13 +1678,14 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.1.tgz",
-      "integrity": "sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.2.tgz",
+      "integrity": "sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -1684,13 +1699,14 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.1.tgz",
-      "integrity": "sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.2.tgz",
+      "integrity": "sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "win32"
@@ -1704,13 +1720,14 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.1.tgz",
-      "integrity": "sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.2.tgz",
+      "integrity": "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "win32"
@@ -1724,10 +1741,11 @@
       }
     },
     "node_modules/lightningcss/node_modules/detect-libc": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
-      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
       }
@@ -1776,12 +1794,13 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/merge2": {
@@ -1812,42 +1831,6 @@
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/minizlib": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.2.tgz",
-      "integrity": "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==",
-      "dev": true,
-      "dependencies": {
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "dev": true,
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mri": {
@@ -2647,35 +2630,24 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.11.tgz",
-      "integrity": "sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==",
-      "dev": true
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.16.tgz",
+      "integrity": "sha512-pONL5awpaQX4LN5eiv7moSiSPd/DLDzKVRJz8Q9PgzmAdd1R4307GQS2ZpfiN7ZmekdQrfhZZiSE5jkLR4WNaA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tapable": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.2.tgz",
-      "integrity": "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/tar": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
-      "dev": true,
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
-        "yallist": "^5.0.0"
       },
-      "engines": {
-        "node": ">=18"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/thenby": {
@@ -2842,15 +2814,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/yallist": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "dev": true,
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@tailwindcss/cli": "^4.0.0",
+    "@tailwindcss/cli": "^4.1.16",
     "@tailwindcss/typography": "^0.5.9",
     "autoprefixer": "^10.4.16",
     "postcss": "^8.4.31",
@@ -8,7 +8,7 @@
     "prettier": "^3.0.3",
     "prettier-plugin-go-template": "^0.0.15",
     "prettier-plugin-tailwindcss": "^0.5.6",
-    "tailwindcss": "^4.0.0"
+    "tailwindcss": "^4.1.16"
   },
   "dependencies": {
     "package.json": "^2.0.1"


### PR DESCRIPTION
This PR introduces a visual change on the `/docs` and `/blog` endpoints. Until now we had 2 styles fighting together: the one we handcrafted from a community-published template, and the Docsy default theme.
In this PR I lift the first's theme into a modern and readable template to improve the _look & feel_ while keeping the Docsy's capabilities under the hood. It changes nothing for the downstream repositories, simply the style.

It is inspired by Kubernetes, OpenTelemetry and Pulumi websites/docs.

> [!TIP]
> This PR has been deployed on a [temporary Netlify website](https://ctfer-io-website-pr-99.netlify.app) for you to preview :wink:

The header and footer is consistent over all pages now ! :partying_face: 

Here are a few screenshots of what it introduces:

## Navigation (left) sidebar

Its style is based upon the `tree` output, an echo to the code-centric work within the organization.
It properly handles multi-line long titles, and does it only with CSS.
The root-level projects appear differently from subs (bigger, bolder).

<img width="289" height="347" alt="image" src="https://github.com/user-attachments/assets/a8113efb-4c7b-4ee1-b3f3-92d82b6b53e2" />

## Page (right) sidebar

This one is directly lifted from Docsy, nothing changed.

<img width="286" height="295" alt="image" src="https://github.com/user-attachments/assets/2a6dc915-fea8-4ea5-b320-a90c3dec07c6" />

It is still printable with CTRL+P, tho I think it poorly uses space and header/footer display could be improved. I leave this as future work as it is not mandatory (to me) to be shipped with this PR that focuses on consistent styling.

## Tables

Simply replace greyscale by a rust/red-scale for consistency with the org's colors; round its corners and delimit the outside to be consistent with figures.

<img width="271" height="343" alt="image" src="https://github.com/user-attachments/assets/aed776f7-867f-493e-b260-2fed8960dd5d" />

## Sub-cards

Instead of a list of subs, they are represented by cards that feels way more modern (order is maintained).

<img width="1022" height="511" alt="image" src="https://github.com/user-attachments/assets/3c604ede-79d6-4b6f-b6bd-36cd98f8560c" />

---

> [!WARNING]
> The PR's content has essentially been written by Claude Opus 4.8 in High effort.
> I don't have the skills for doing such thing myself, but I reviewed every single line of code it produced.

Due to the homepage's usage of Tailwind and Docsy's usage of Bootstrap, there is duplicated code that it mandatory to align both on the same designs. It could be highly improved in the future, but I don't think in a **near** future.